### PR TITLE
Support multiple breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ class MyController
 end
 ```
 
-When after create new breadcrumb stack, if you want to push to an existing stack.
+You can push a new element to an arbitrary stack by specifying an `index` option.
 
 ```ruby
 class MyController

--- a/README.md
+++ b/README.md
@@ -59,6 +59,55 @@ class MyController
 end
 ```
 
+### Multiple breadcrumns
+For using multiple breadcrumbs, call `next_breadcrumbs` to create new breadcrumb stack.
+
+```ruby
+class MyController
+
+  def index
+    # ...
+
+    add_breadcrumb "home", :root_path
+    add_breadcrumb "my", :my_path
+    add_breadcrumb "index", index_path
+
+    next_breadcrumbs
+
+    add_breadcrumb "home", :root_path
+    add_breadcrumb "another", :another_path
+    add_breadcrumb "index", index_path
+
+  end
+
+end
+```
+
+When after create new breadcrumb stack, if you want to push to an existing stack.
+
+```ruby
+class MyController
+
+  add_breadcrumb "home", :root_path
+  next_breadcrumbs
+  add_breadcrumb "home", :root_path
+
+  def index
+    # ...
+
+    add_breadcrumb "my", :my_path, index: 0
+    add_breadcrumb "index", index_path, index: 0
+
+    add_breadcrumb "another", :another_path, index: 1
+    add_breadcrumb "index", index_path, index: 1
+  end
+
+end
+```
+
+
+### Render
+
 In your view, you can render the breadcrumb menu with the `render_breadcrumbs` helper.
 
 ```html
@@ -88,6 +137,7 @@ Current possible options are:
 
 - `:separator`
 - `:tag`
+- `:list_separator`
 
 To use with Bootstrap you might use the following:
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ end
 
 ### Restricting breadcrumb scope
 
-The `add_breadcrumb` method understands all options you are used to pass to a Rails controller filter. In fact, behind the scenes this method uses a `before_filter` to store the tab in the `@breadcrumbs` and `@breadcrumbs_list` variable.
+The `add_breadcrumb` method understands all options you are used to pass to a Rails controller filter. In fact, behind the scenes this method uses a `before_filter` to store the tab in the `@breadcrumbs` and `@breadcrumbs_list` variables.
 
 Taking advantage of Rails filter options, you can restrict a tab to a selected group of actions in the same controller.
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ end
 
 ### Restricting breadcrumb scope
 
-The `add_breadcrumb` method understands all options you are used to pass to a Rails controller filter. In fact, behind the scenes this method uses a `before_filter` to store the tab in the `@breadcrumbs` variable.
+The `add_breadcrumb` method understands all options you are used to pass to a Rails controller filter. In fact, behind the scenes this method uses a `before_filter` to store the tab in the `@breadcrumbs_list` variable.
 
 Taking advantage of Rails filter options, you can restrict a tab to a selected group of actions in the same controller.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ class MyController
 end
 ```
 
-### Multiple breadcrumns
-For using multiple breadcrumbs, call `next_breadcrumbs` to create new breadcrumb stack.
+### Multiple breadcrumbs
+For using multiple breadcrumbs, call `next_breadcrumbs` to create a new breadcrumb stack.
 
 ```ruby
 class MyController
@@ -231,7 +231,7 @@ end
 
 ### Restricting breadcrumb scope
 
-The `add_breadcrumb` method understands all options you are used to pass to a Rails controller filter. In fact, behind the scenes this method uses a `before_filter` to store the tab in the `@breadcrumbs_list` variable.
+The `add_breadcrumb` method understands all options you are used to pass to a Rails controller filter. In fact, behind the scenes this method uses a `before_filter` to store the tab in the `@breadcrumbs` and `@breadcrumbs_list` variable.
 
 Taking advantage of Rails filter options, you can restrict a tab to a selected group of actions in the same controller.
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -15,7 +15,7 @@ module BreadcrumbsOnRails
       extend          ClassMethods
       helper          HelperMethods
       helper_method   :add_breadcrumb, :breadcrumbs
-      helper_method   :next_breadcrumbs_list, :breadcrumbs_list
+      helper_method   :next_breadcrumbs, :breadcrumbs_list
 
       unless base.respond_to?(:before_action)
         base.alias_method :before_action, :before_filter
@@ -32,7 +32,7 @@ module BreadcrumbsOnRails
       self.breadcrumbs_list.last
     end
 
-    def next_breadcrumbs_list
+    def next_breadcrumbs
       self.breadcrumbs_list << []
     end
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -27,15 +27,15 @@ module BreadcrumbsOnRails
     def add_breadcrumb(name, path = nil, options = {})
       option_index = options.delete(:index)
 
-      if option_index
-        self.breadcrumbs_list[option_index] << Breadcrumbs::Element.new(name, path, options)
-      else
-        self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
-      end
+      self.breadcrumbs(option_index) << Breadcrumbs::Element.new(name, path, options)
     end
 
-    def breadcrumbs
-      self.breadcrumbs_list.last
+    def breadcrumbs(index = nil)
+      if index
+        self.breadcrumbs_list[index]
+      else
+        self.breadcrumbs_list.last
+      end
     end
 
     def next_breadcrumbs

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -99,6 +99,7 @@ module BreadcrumbsOnRails
 
       def render_breadcrumbs(options = {}, &block)
         option_builder = options.delete(:builder)
+        option_list_separator = options.delete(:list_separator)
         breadcrumbs_list.map do |bcs|
           builder = (option_builder || Breadcrumbs::SimpleBuilder).new(self, bcs, options)
           content = builder.render
@@ -107,7 +108,7 @@ module BreadcrumbsOnRails
           else
             content
           end
-        end.join( options.delete(:list_separator)).html_safe
+        end.join(option_list_separator).html_safe
       end
     end
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -25,7 +25,13 @@ module BreadcrumbsOnRails
     protected
 
     def add_breadcrumb(name, path = nil, options = {})
-      self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
+      option_index = options.delete(:index)
+
+      if option_index
+        self.breadcrumbs_list[option_index] << Breadcrumbs::Element.new(name, path, options)
+      else
+        self.breadcrumbs << Breadcrumbs::Element.new(name, path, options)
+      end
     end
 
     def breadcrumbs

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -31,10 +31,11 @@ module BreadcrumbsOnRails
     end
 
     def breadcrumbs(index = nil)
+      @breadcrumbs = self.breadcrumbs_list.last # for compatible to single breadcrumbs version. 
       if index
         self.breadcrumbs_list[index]
       else
-        self.breadcrumbs_list.last
+        @breadcrumbs
       end
     end
 

--- a/lib/breadcrumbs_on_rails/action_controller.rb
+++ b/lib/breadcrumbs_on_rails/action_controller.rb
@@ -15,6 +15,7 @@ module BreadcrumbsOnRails
       extend          ClassMethods
       helper          HelperMethods
       helper_method   :add_breadcrumb, :breadcrumbs
+      helper_method   :next_breadcrumbs_list, :breadcrumbs_list
 
       unless base.respond_to?(:before_action)
         base.alias_method :before_action, :before_filter
@@ -28,7 +29,15 @@ module BreadcrumbsOnRails
     end
 
     def breadcrumbs
-      @breadcrumbs ||= []
+      self.breadcrumbs_list.last
+    end
+
+    def next_breadcrumbs_list
+      self.breadcrumbs_list << []
+    end
+
+    def breadcrumbs_list
+      @breadcrumbs_list ||= [[]]
     end
 
     module Utils
@@ -83,15 +92,17 @@ module BreadcrumbsOnRails
     module HelperMethods
 
       def render_breadcrumbs(options = {}, &block)
-        builder = (options.delete(:builder) || Breadcrumbs::SimpleBuilder).new(self, breadcrumbs, options)
-        content = builder.render.html_safe
-        if block_given?
-          capture(content, &block)
-        else
-          content
-        end
+        option_builder = options.delete(:builder)
+        breadcrumbs_list.map do |bcs|
+          builder = (option_builder || Breadcrumbs::SimpleBuilder).new(self, bcs, options)
+          content = builder.render
+          if block_given?
+            capture(content, &block)
+          else
+            content
+          end
+        end.join( options.delete(:list_separator)).html_safe
       end
-
     end
 
   end

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -91,15 +91,84 @@ class ClassLevelExampleControllerTest < ActionController::TestCase
 
 end
 
+class MultipleExampleController < ActionController::Base
+  include BreadcrumbsOnRails::ActionController
+
+  def self.controller_name; "example"; end
+  def self.controller_path; "example"; end
+
+  layout false
+
+  def action_default
+    add_breadcrumb "String", "/"
+    add_breadcrumb "Hoge", "/hoge/"
+    add_breadcrumb "Me", "/hoge/moge"
+
+    next_breadcrumbs_list
+
+    add_breadcrumb "String", "/"
+    add_breadcrumb "Moge", "/moge/"
+    add_breadcrumb "You", "/hoge/moge"
+
+    execute("action_default")
+  end
+
+  def action_compute_paths
+    add_breadcrumb "String", "/"
+    add_breadcrumb "Proc", proc { |c| "/?proc" }
+    add_breadcrumb "Polymorphic", [:admin, :namespace]
+
+    next_breadcrumbs_list
+
+    add_breadcrumb "String", "/hoge/"
+    add_breadcrumb "Proc", proc { |c| "/?proc" }
+    add_breadcrumb "xxPolymorphic", [:admin, :namespace]
+
+    execute("action_default")
+  end
+
+
+  private
+
+  def execute(method)
+    if method.to_s =~ /^action_(.*)/
+      render :action => (params[:template] || 'default')
+    end
+  end
+
+  def admin_namespace_path(*)
+    "/?polymorphic"
+  end
+  helper_method :admin_namespace_path
+
+end
+
+class MultipleExampleControllerTest < ActionController::TestCase
+  tests MultipleExampleController
+
+  def test_render_default
+    get :action_default
+    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/hoge/">Hoge</a> &raquo; <a href="/hoge/moge">Me</a>|<a href="/">String</a> &raquo; <a href="/moge/">Moge</a> &raquo; <a href="/hoge/moge">You</a>),
+                      @response.body
+  end
+
+  def test_render_compute_paths
+    get :action_compute_paths
+    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">Polymorphic</a>|<a href="/hoge/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">xxPolymorphic</a>),
+                      @response.body
+  end
+
+end
+
 class ExampleHelpersTest < ActionView::TestCase
   tests BreadcrumbsOnRails::ActionController::HelperMethods
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::UrlHelper
 
-  attr_accessor :breadcrumbs
+  attr_accessor :breadcrumbs_list
 
   setup do
-    self.breadcrumbs = []
+    self.breadcrumbs_list = [[]]
   end
 
   def test_render_breadcrumbs

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -127,6 +127,58 @@ class MultipleExampleController < ActionController::Base
     execute("action_default")
   end
 
+  private
+
+  def execute(method)
+    if method.to_s =~ /^action_(.*)/
+      render :action => (params[:template] || 'default')
+    end
+  end
+
+  def admin_namespace_path(*)
+    "/?polymorphic"
+  end
+  helper_method :admin_namespace_path
+
+end
+
+class MultipleWithIndexExampleController < ActionController::Base
+  include BreadcrumbsOnRails::ActionController
+
+  def self.controller_name; "example"; end
+  def self.controller_path; "example"; end
+
+  layout false
+
+  def action_default
+    add_breadcrumb "String", "/"
+    add_breadcrumb "Hoge", "/hoge/"
+
+    next_breadcrumbs
+
+    add_breadcrumb "String", "/"
+    add_breadcrumb "Moge", "/moge/"
+
+    add_breadcrumb "Me", "/hoge/moge", { index: 0 }
+    add_breadcrumb "You", "/hoge/moge"
+
+    execute("action_default")
+  end
+
+  def action_compute_paths
+    add_breadcrumb "String", "/"
+    add_breadcrumb "Proc", proc { |c| "/?proc" }
+
+    next_breadcrumbs
+
+    add_breadcrumb "String", "/hoge/"
+    add_breadcrumb "Proc", proc { |c| "/?proc" }
+
+    add_breadcrumb "Polymorphic", [:admin, :namespace], { index: 0 }
+    add_breadcrumb "xxPolymorphic", [:admin, :namespace]
+
+    execute("action_default")
+  end
 
   private
 
@@ -145,6 +197,23 @@ end
 
 class MultipleExampleControllerTest < ActionController::TestCase
   tests MultipleExampleController
+
+  def test_render_default
+    get :action_default
+    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/hoge/">Hoge</a> &raquo; <a href="/hoge/moge">Me</a>|<a href="/">String</a> &raquo; <a href="/moge/">Moge</a> &raquo; <a href="/hoge/moge">You</a>),
+                      @response.body
+  end
+
+  def test_render_compute_paths
+    get :action_compute_paths
+    assert_dom_equal  %(<a href="/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">Polymorphic</a>|<a href="/hoge/">String</a> &raquo; <a href="/?proc">Proc</a> &raquo; <a href="/?polymorphic">xxPolymorphic</a>),
+                      @response.body
+  end
+
+end
+
+class MultipleWithIndexExampleControllerTest < ActionController::TestCase
+  tests MultipleWithIndexExampleController
 
   def test_render_default
     get :action_default

--- a/test/unit/action_controller_test.rb
+++ b/test/unit/action_controller_test.rb
@@ -104,7 +104,7 @@ class MultipleExampleController < ActionController::Base
     add_breadcrumb "Hoge", "/hoge/"
     add_breadcrumb "Me", "/hoge/moge"
 
-    next_breadcrumbs_list
+    next_breadcrumbs
 
     add_breadcrumb "String", "/"
     add_breadcrumb "Moge", "/moge/"
@@ -118,7 +118,7 @@ class MultipleExampleController < ActionController::Base
     add_breadcrumb "Proc", proc { |c| "/?proc" }
     add_breadcrumb "Polymorphic", [:admin, :namespace]
 
-    next_breadcrumbs_list
+    next_breadcrumbs
 
     add_breadcrumb "String", "/hoge/"
     add_breadcrumb "Proc", proc { |c| "/?proc" }

--- a/test/views/example/default.html.erb
+++ b/test/views/example/default.html.erb
@@ -1,1 +1,1 @@
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs(list_separator: "|") %>


### PR DESCRIPTION
とりあえず書いてみた感じ

`next_breadcrumbs` で `add_breadcrumb` する対象のパンくずリストを切り替える

---
Use a new helper_method "next_breadcrumbs" to support multiple breadcrumbs.
